### PR TITLE
Adding support for Webpack 2, which doesn’t allow custom args on the …

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var assign = require('object-assign');
 var getCLIOptions = function () {
   var modules = [];
   process.argv.forEach(function (val, index, array) {
-    if (val.indexOf('--link') > -1) {
+    if (val.indexOf('--link') > -1 || val.indexOf('--env.link') > -1) {
       var args = val.split('=')[1];
       if (args) { modules = args.split(',') }
     }


### PR DESCRIPTION
…CLI, you have to use env.argName instead (https://github.com/webpack/webpack/issues/2254#issuecomment-203528744).